### PR TITLE
Added a parameter for filtering incomplete entries

### DIFF
--- a/PlatformStatusTracker/PlatformStatusTracker.Web/Controllers/HomeController.cs
+++ b/PlatformStatusTracker/PlatformStatusTracker.Web/Controllers/HomeController.cs
@@ -30,7 +30,7 @@ namespace PlatformStatusTracker.Web.Controllers
             return View(await HomeIndexViewModel.CreateAsync(_changeSetRepository));
         }
 
-        public async Task<IActionResult> Feed(bool shouldFilterIncomplete = false)
+        public async Task<IActionResult> Feed(bool shouldFilterIncomplete = true)
         {
             var result = View(await HomeIndexViewModel.CreateAsync(_changeSetRepository));
             result.ContentType = "application/atom+xml";

--- a/PlatformStatusTracker/PlatformStatusTracker.Web/Controllers/HomeController.cs
+++ b/PlatformStatusTracker/PlatformStatusTracker.Web/Controllers/HomeController.cs
@@ -30,7 +30,7 @@ namespace PlatformStatusTracker.Web.Controllers
             return View(await HomeIndexViewModel.CreateAsync(_changeSetRepository));
         }
 
-        public async Task<IActionResult> Feed()
+        public async Task<IActionResult> Feed(bool shouldFilterIncomplete = false)
         {
             var result = View(await HomeIndexViewModel.CreateAsync(_changeSetRepository));
             result.ContentType = "application/atom+xml";

--- a/PlatformStatusTracker/PlatformStatusTracker.Web/ViewModels/Home/HomeIndexViewModel.cs
+++ b/PlatformStatusTracker/PlatformStatusTracker.Web/ViewModels/Home/HomeIndexViewModel.cs
@@ -18,7 +18,7 @@ namespace PlatformStatusTracker.Web.ViewModels.Home
         public DateTime[] Dates { get; private set; }
         public DateTime LastUpdatedAt { get; private set; }
 
-        public static async Task<HomeIndexViewModel> CreateAsync(IChangeSetRepository changeSetRepository)
+        public static async Task<HomeIndexViewModel> CreateAsync(IChangeSetRepository changeSetRepository, bool shouldFilterIncomplete = false)
         {
 #if !FALSE
             var edgeChangeSetsTask = GetChangeSetsByBrowserAsync(changeSetRepository, StatusDataType.Edge);
@@ -44,6 +44,8 @@ namespace PlatformStatusTracker.Web.ViewModels.Home
             var lastUpdated = await statusDataRepository.GetLastUpdated();
 #endif
 
+            var today = shouldFilterIncomplete ? DateTime.Today : DateTime.Now;
+
             return new HomeIndexViewModel()
             {
                 IeChangeSetsByDate = edgeChangeSets.ToDictionary(k => k.Date, v => v),
@@ -53,7 +55,7 @@ namespace PlatformStatusTracker.Web.ViewModels.Home
                 MozillaChangeSetsByDate = mozillaChangeSets.ToDictionary(k => k.Date, v => v),
                 Dates = new[] { edgeChangeSets, chromeChangeSets, webkitWebCoreChangeSets, webkitJavaScriptCoreChangeSets, mozillaChangeSets }
                             .SelectMany(x => x)
-                            .Where(x => x.Changes.Any())
+                            .Where(x => x.Date < today && x.Changes.Any())
                             .Select(x => x.Date)
                             .Distinct()
                             .ToArray(),

--- a/PlatformStatusTracker/PlatformStatusTracker.Web/ViewModels/Home/HomeIndexViewModel.cs
+++ b/PlatformStatusTracker/PlatformStatusTracker.Web/ViewModels/Home/HomeIndexViewModel.cs
@@ -44,7 +44,7 @@ namespace PlatformStatusTracker.Web.ViewModels.Home
             var lastUpdated = await statusDataRepository.GetLastUpdated();
 #endif
 
-            var today = shouldFilterIncomplete ? DateTime.Today : DateTime.Now;
+            var today = shouldFilterIncomplete ? DateTime.UtcNow.Date : DateTime.UtcNow;
 
             return new HomeIndexViewModel()
             {


### PR DESCRIPTION
Feed readers such as Feedly do not update feed entries after fetching them, which causes Feedly to return a snapshot of the entry at the time of fetching, rather than the final entry with all of the changes.

Users can add ?shouldFilterIncomplete=true and only get finalized entries from the day before, as no changes will ever be added into them.