### PR TITLE
fix(Feed): update 'update' field in feed when statuses have been modified

### DIFF
--- a/PlatformStatusTracker/PlatformStatusTracker.Core/Model/ChangeSet.cs
+++ b/PlatformStatusTracker/PlatformStatusTracker.Core/Model/ChangeSet.cs
@@ -25,6 +25,11 @@ namespace PlatformStatusTracker.Core.Model
         /// </summary>
         public DateTime From { get; set; }
 
+        /// <summary>
+        /// ChangeSet's updated date and time.
+        /// </summary>
+        public DateTime UpdatedAt { get; set; }
+
         public static ChangeSet[] GetChangeSetsFromPlatformStatuses(PlatformStatuses[] platformStatuses)
         {
             // FIXME: We must handle unexpected errors.

--- a/PlatformStatusTracker/PlatformStatusTracker.Web/ViewModels/Home/HomeIndexViewModel.cs
+++ b/PlatformStatusTracker/PlatformStatusTracker.Web/ViewModels/Home/HomeIndexViewModel.cs
@@ -67,5 +67,19 @@ namespace PlatformStatusTracker.Web.ViewModels.Home
                                                            .OrderByDescending(x => x.Date)
                                                            .ToArray();
         }
+
+        public DateTime GetUpdatedAtByDate(DateTime date)
+        {
+            var dateTime = date;
+            foreach (var changeSetsByDate in new [] { IeChangeSetsByDate, ChromeChangeSetsByDate, WebKitJavaScriptCoreChangeSetsByDate, WebKitWebCoreChangeSetsByDate, MozillaChangeSetsByDate })
+            {
+                if (changeSetsByDate.TryGetValue(dateTime, out var t) && t.UpdatedAt > dateTime)
+                {
+                    dateTime = t.UpdatedAt;
+                }
+            }
+
+            return dateTime;
+        }
     }
 }

--- a/PlatformStatusTracker/PlatformStatusTracker.Web/Views/Home/Feed.cshtml
+++ b/PlatformStatusTracker/PlatformStatusTracker.Web/Views/Home/Feed.cshtml
@@ -22,7 +22,7 @@
             <title>@date.ToString("yyyy-MM-dd", new CultureInfo("en-us"))</title>
             <link href="@Url.Action("Changes", "Home", new { Date = date.ToString("yyyy-MM-dd") }, "http")" />
             <id>@Url.Action("Changes", "Home", new { Date = date.ToString("yyyy-MM-dd") }, "http")</id>
-            <updated>@date.ToString("yyyy-MM-dd'T'HH:mm:ss.fffK", DateTimeFormatInfo.InvariantInfo)</updated>
+            <updated>@Model.GetUpdatedAtByDate(date).ToString("yyyy-MM-dd'T'HH:mm:ss.fffK", DateTimeFormatInfo.InvariantInfo)</updated>
             <content type="html">
                 @{
                     var content = Html.Partial("Partial/ChangeSets", new ChangeSetsViewModel


### PR DESCRIPTION
Add "UpdatedAt" property as updated time of changesets.
It is used in "updated" field of feed entries, which make feed reader possible to detect update.

- See also: #12 