### PR TITLE
fix: WebKitPlatformStatus only includes 'features'

### DIFF
--- a/PlatformStatusTracker/PlatformStatusTracker.Core/Data/PlatformStatus.cs
+++ b/PlatformStatusTracker/PlatformStatusTracker.Core/Data/PlatformStatus.cs
@@ -24,7 +24,7 @@ namespace PlatformStatusTracker.Core.Data
         {
             var statuses = JsonConvert.DeserializeObject<WebKitPlatformStatuses>(jsonValue);
 
-            return statuses.Features.Concat(statuses.Specification).Where(x => x.Status != null).ToArray();
+            return statuses.Features/*.Concat(statuses.Specification)*/.Where(x => x.Status != null).ToArray();
         }
 
         public static MozillaPlatformStatus[] DeserializeForMozillaStatus(string jsonValue)


### PR DESCRIPTION
WebKit's features.json may contain items of the same name in 'specifications' and 'features' sections.
Temporarily, only 'features' section should be used.

http://svn.webkit.org/repository/webkit/trunk/Source/JavaScriptCore/features.json
https://trac.webkit.org/changeset/280456/webkit
https://github.com/mayuki/PlatformStatusTracker/runs/3199499945?check_suite_focus=true#step:4:53