### PR TITLE
Update WebKit URLs

### DIFF
--- a/PlatformStatusTracker/PlatformStatusTracker.Core/Model/DataUpdateAgent.cs
+++ b/PlatformStatusTracker/PlatformStatusTracker.Core/Model/DataUpdateAgent.cs
@@ -21,8 +21,8 @@ namespace PlatformStatusTracker.Core.Model
         {
             (StatusDataType.Chromium, "http://www.chromestatus.com/features.json"),
             (StatusDataType.Edge, "https://raw.githubusercontent.com/MicrosoftEdge/Status/production/status.json"),
-            (StatusDataType.WebKitWebCore, "http://svn.webkit.org/repository/webkit/trunk/Source/WebCore/features.json"),
-            (StatusDataType.WebKitJavaScriptCore, "http://svn.webkit.org/repository/webkit/trunk/Source/JavaScriptCore/features.json"),
+            (StatusDataType.WebKitWebCore, "https://raw.githubusercontent.com/WebKit/WebKit/main/Source/WebCore/features.json"),
+            (StatusDataType.WebKitJavaScriptCore, "https://raw.githubusercontent.com/WebKit/WebKit/main/Source/JavaScriptCore/features.json"),
             //(StatusDataType.Mozilla, "https://platform-status.mozilla.org/api/status"),
         };
 


### PR DESCRIPTION
WebKit recently [moved to GitHub](https://webkit.org/blog/13140/webkit-on-github/). This commit updates the `features.json` URLs from the old SVN trunk to their GitHub counterparts.

Note that the old SVN URLs are no longer up-to-date with the most recent commits. This can be verified by comparing the two URLs below:

- https://svn.webkit.org/repository/webkit/trunk/Source/WebCore/features.json
- https://raw.githubusercontent.com/WebKit/WebKit/main/Source/WebCore/features.json

The SVN URL has no mention of “Reporting API“, which [was recently added to the repo](https://github.com/WebKit/WebKit/commit/31055cc795dc775595642aae8974f226685d4ccd).